### PR TITLE
78: Fix creating a guide without content

### DIFF
--- a/src/components/pages/create/Create.js
+++ b/src/components/pages/create/Create.js
@@ -9,6 +9,7 @@ import DOMPurify from "dompurify";
 import { useNavigate } from "react-router-dom";
 import EditorButtons from "../../common/md/editor/EditorButtons";
 import Editor from "../../common/md/editor/Editor";
+import messages from "../../../store/messages";
 
 const Create = () => {
 	const dispatch = useDispatch();
@@ -21,7 +22,7 @@ const Create = () => {
 
 	function createGuideHandler(isPublic) {
 		if (title === '' || content === '') {
-			dispatch(showAlert('error', 'Fields cant be empty!'));
+			dispatch(showAlert('error', messages.error['error_fields']));
 			return;
 		}
 		dispatch(createGuide(title, content, note, isPublic, () => navigate('/')));
@@ -29,7 +30,7 @@ const Create = () => {
 	return (
 		<div className="bg-secondary-light p-10 pt-24">
 			<div className="flex justify-center">
-				<Alert size="half" />
+				<Alert size={"half"} />
 			</div>
 			<EditorButtons onCreateHandler={createGuideHandler} mode="create" />
 			<Editor

--- a/src/components/pages/guides/FeaturedGuides.js
+++ b/src/components/pages/guides/FeaturedGuides.js
@@ -21,7 +21,7 @@ const FeaturedGuides = ({ userId }) => {
 		<div className="w-[40%] bg-light-main p-5 rounded">
 			<h2 className=" text-2xl my-5">More from the author</h2>
 			{isLoading && <Loading />}
-			{guides && guides.map(guide =>
+			{guides?.map(guide =>
 				<NavLink to={`/guides/${guide.guideId}`} key={guide.guideId} className="flex mb-5 h-fit">
 					<img src={cardImg} alt="Preview" className="w-[30%] mr-5 rounded" />
 					<div>

--- a/src/components/pages/guides/GuideContent.js
+++ b/src/components/pages/guides/GuideContent.js
@@ -27,7 +27,7 @@ const GuideContent = ({ id, activeGuide, activeUser }) => {
 			<div className="flex justify-center">
 				<Alert size={"half"} />
 			</div>
-			{activeUser.userId === activeGuide.user?.userId &&
+			{activeUser?.userId === activeGuide.user?.userId &&
 				<div className="flex gap-5">
 					<NavLink className="inline-block py-2 px-4 my-5 rounded-md bg-secondary-main text-light-main text-lg font-medium"
 						to={`/guides/${id}/update`}>
@@ -41,7 +41,7 @@ const GuideContent = ({ id, activeGuide, activeUser }) => {
 			<GuideInfo activeGuide={activeGuide} />
 			<div className="flex gap-10">
 				<MarkdownContent content={content} lastModified={activeGuide.lastModified} className="h-fit" />
-				<FeaturedGuides userId={activeGuide.user.userId} guideId={id} />
+				<FeaturedGuides userId={activeGuide?.user?.userId} guideId={id} />
 			</div>
 		</div>
 	)

--- a/src/components/pages/guides/GuideInfo.js
+++ b/src/components/pages/guides/GuideInfo.js
@@ -12,13 +12,13 @@ const GuideInfo = ({ activeGuide }) => {
 				<>
 					<div>
 						<span className="text-gray-dark text-xl italic">Author: </span>
-						<NavLink className="ml-5" to={"/instructors/" + activeGuide.user.userId}>
-							{activeGuide.user.userDetails?.avatar ?
+						<NavLink className="ml-5" to={"/instructors/" + activeGuide?.user?.userId}>
+							{activeGuide?.user?.userDetails?.avatar ?
 								<img src={"/" + activeGuide.user.userDetails.avatar} alt="Avatar"
 									className="w-[50px] inline rounded-[50%] mr-2" />
 								:
 								<FaUser className="rounded-[50%] inline bg-success-main text-5xl p-1 mr-5" />}
-							<h3 className="inline text-xl">{activeGuide.user.firstName} {activeGuide.user.lastName}</h3>
+							<h3 className="inline text-xl">{activeGuide?.user?.firstName} {activeGuide?.user?.lastName}</h3>
 						</NavLink>
 					</div>
 					<div className=" text-gray-dark text-xl italic font-bold">

--- a/src/components/pages/update/Update.js
+++ b/src/components/pages/update/Update.js
@@ -11,6 +11,7 @@ import { showAlert } from "../../../store/slices/uiSlice";
 import messages from "../../../store/messages";
 import GuideHeader from "../guides/GuideHeader";
 import { useNavigate } from "react-router-dom";
+import Alert from "../../ui/Alert";
 
 
 
@@ -27,7 +28,7 @@ const Update = () => {
 
 	function updateGuideHandler(isPublic) {
 		if (title === '' || content === '') {
-			dispatch(showAlert('success', messages.error['error_fields']));
+			dispatch(showAlert('error', messages.error['error_fields']));
 			return;
 		}
 		dispatch(updateGuide(title, content, guideId, note, isPublic, () => {
@@ -38,6 +39,9 @@ const Update = () => {
 		<>
 			<GuideHeader />
 			<div className="bg-secondary-light p-10">
+				<div className="flex justify-center">
+					<Alert size="half" />
+				</div>
 				<EditorButtons onUpdateHandler={updateGuideHandler} published={published} mode="update" />
 				<Editor
 					title={title}

--- a/src/components/ui/Alert.js
+++ b/src/components/ui/Alert.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
 
@@ -9,29 +9,27 @@ const Alert = ({ size = "full" }) => {
 	const [shouldShow, setShouldShow] = useState(false);
 
 	const { type, msgObj } = useSelector(state => state.ui.alert);
-	const { msg, pages } = msgObj;
+	const {msg, pages} = msgObj
+	
+	const checkPage = useCallback(page => {
+		if (page === '*' || page === pathname)
+			return true;
+
+		if ((page[0] === '^' && pathname.startsWith(page.slice(1))) ||
+			(page[page.length - 1] === '^' && pathname.endsWith(page.slice(0, page.length - 1))))
+			return true;
+	},[pathname]);
 
 	useEffect(() => {
-		function handlePages() {
-			if (pages.length === 1) {
-				if (pages[0] === '*' || pages[0] === pathname || (pages[0].startsWith('/guides') && pathname.startsWith('/guides')))
+			for (const page of pages) {
+				if (checkPage(page)) {
 					setShouldShow(true);
+					break;
+				}
 				else
 					setShouldShow(false);
 			}
-			else if (pages.length > 1) {
-				for (const element of pages) {
-					if (element === pathname || (element.startsWith('/guides') && pathname.startsWith('/guides'))) {
-						setShouldShow(true);
-						break;
-					}
-					else
-						setShouldShow(false);
-				}
-			}
-		}
-		handlePages();
-	}, [pathname, pages]);
+	}, [pathname, pages, checkPage]);
 
 	return (
 		<div

--- a/src/store/controllers/authController.js
+++ b/src/store/controllers/authController.js
@@ -48,6 +48,10 @@ export const getUserByToken = function () {
 			dispatch(userActions.setUser(data));
 		} catch (err) {
 			dispatch(userActions.setUser(null));
+			if (document.cookie.startsWith('auth_token'))
+				document.cookie = 'auth_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+
+			console.log(err.message);
 			dispatch(showAlert('error', messages.error[err.message]));
 		}
 	};

--- a/src/store/controllers/common/request.js
+++ b/src/store/controllers/common/request.js
@@ -43,7 +43,7 @@ export const sendRequest =  async(url, request, body, isFile) => {
 }
 
 export const handleErrorMessages = (dispatch, msg) => {
-	if (msg === 'unauthorized')
+	if (msg === 'unauthorized' || msg === 'not_enough_segments')
 		dispatch(getUserByToken());
 	else if (msg === 'guides_not_found' || msg === 'requested_a_non-existent_page')
 		dispatch(uiActions.setError(messages.error[msg]));

--- a/src/store/messages.js
+++ b/src/store/messages.js
@@ -1,10 +1,14 @@
+// "^" in the beginning of page means it should start like that
+// "^" in the end of page means it should end like that
+
 const messages = {
 	error: {
 		"server_error": {msg: 'Error! Unexpected error occured.', pages: ['*']},
-		"error_fields": {msg: "Error! Fields can't be empty", pages:['/auth/login', '/auth/register', '/profile']},
+		"error_fields": {msg: "Error! Fields can't be empty", pages:['/auth/login', '/auth/register', '/profile', '/create', '/update^']},
 		"value_error.email": {msg: 'Error! Invalid email format.', pages: ['/auth/login']},
 		"invalid_credentials": {msg: 'Error! Wrong email or password.', pages: ['/auth/login']},
 		"unauthorized": {msg: 'Error! Your session has expired.', pages:['/']},
+		"not_enough_segments": {msg: 'Error! Your session has expired.', pages:['/']},
 		"error_passwords": {msg: "Error! Password don't match.", pages: ['/auth/register', '/profile']},
 		'value_error.any_str.min_length': {msg: 'Error! Password needs to have at least 8 characters.', pages: ['/auth/register']},
 		"guides_not_found": 'No guides found.',
@@ -18,9 +22,9 @@ const messages = {
 		'account_update_success': {msg: 'Success! Data successfully updated.', pages: ['/profile']},
 		'pw_change_success': {msg: 'Success! Password successfully changed.', pages: ['/profile']},
 		'guide_create_success': {msg: 'Success! Guide successfully created.', pages: ['/create']},
-		'guide_draft_success': {msg: 'Success! Guide succesfully saved as a draft.', pages: ['/guides']},
-		'guide_update_success': {msg: 'Success! Guide successfully updated.', pages: ['/guides']},
-		'guide_delete_success': {msg: 'Success! Guide successfully deleted.', pages: ['/guides']}
+		'guide_draft_success': {msg: 'Success! Guide succesfully saved as a draft.', pages: ['^/guides']},
+		'guide_update_success': {msg: 'Success! Guide successfully updated.', pages: ['^/guides']},
+		'guide_delete_success': {msg: 'Success! Guide successfully deleted.', pages: ['^/guides']}
 	}
 }
 

--- a/src/store/slices/uiSlice.js
+++ b/src/store/slices/uiSlice.js
@@ -11,7 +11,7 @@ const uiSlice = createSlice({
 	initialState,
 	reducers: {
 		setAlert(state, action) {
-			state.alert = action.payload;
+			state.alert= action.payload;
 		},
 		setError(state, action) {
 			state.error = action.payload;


### PR DESCRIPTION
Added checks for empty content when creating and updating a guide and showing appropriate message

Refactored Alert to be shown if pathname starts or ends with certain page name (example: /update^ - ends with /update)

Fixed `Alert` issue when token exists but is expired